### PR TITLE
Fix log parser failing on newer RimWorld log formats

### DIFF
--- a/assets/js/check.js
+++ b/assets/js/check.js
@@ -74,7 +74,7 @@ function checkStartup(log) {
     const startupLogs = getStartupLogs(log);
     const startupErrors = getErrors(startupLogs);
     const list = createOutputList("startup-errors-list", startupErrors, newLogListItem, "Errors at startup");
-    output.append(list);
+    if (list) output.append(list);
 }
 
 function checkLoadedGame(log) {
@@ -86,14 +86,14 @@ function checkLoadedGame(log) {
 
     const mods = getLoadedMods(loadedLog);
     const list = createOutputList("active-mods-list", mods, newListItem, "Active mods");
-    output.prepend(list);
+    if (list) output.prepend(list);
 
     const consoleLogs = getConsoleLogs(loadedLog);
     const warnings = getWarnings(consoleLogs);
     const errors = getErrors(consoleLogs);
     const combined = warnings.concat(errors);
     const list2 = createOutputList("warnings-errors-runtime-list", combined, newLogListItem, "Errors & warnings after load");
-    output.append(list2);
+    if (list2) output.append(list2);
 }
 
 function getLoadedMods(loadedLog) {
@@ -151,7 +151,7 @@ function parseOutput(log, situation) {
 }
 
 function createOutputList(listId, items, itemConstructor, title) {
-    if(items.length == 0) return;
+    if(!items || items.length == 0) return null;
 
     const list = document.createElement("section");
     list.id = listId;
@@ -180,6 +180,9 @@ function newListItem(text) {
 }
 
 function newLogListItem(logItems) {
+    if (!logItems || !Array.isArray(logItems) || logItems.length === 0 || !logItems[0]) {
+        return null;
+    }
     const li = document.createElement("li");
     const flex = document.createElement("div");
     const content = document.createElement("p");

--- a/assets/js/check.js
+++ b/assets/js/check.js
@@ -127,10 +127,14 @@ function iterateLog(slicedLog, situation) {
 }
 
 function getWarnings(consoleLogs) {
-    return _.filter(consoleLogs, log => log[0].type === "warning");
+    // consoleLogs is an object from _.groupBy, convert to array of arrays
+    const logsArray = Object.values(consoleLogs);
+    return _.filter(logsArray, log => log && log[0] && log[0].type === "warning");
 }
 function getErrors(consoleLogs) {
-    return _.filter(consoleLogs, log => log[0].type === "error" || log[0].type === "exception");
+    // consoleLogs is an object from _.groupBy, convert to array of arrays  
+    const logsArray = Object.values(consoleLogs);
+    return _.filter(logsArray, log => log && log[0] && (log[0].type === "error" || log[0].type === "exception"));
 }
 
 function parseOutput(log, situation) {

--- a/assets/js/check.js
+++ b/assets/js/check.js
@@ -78,7 +78,10 @@ function checkStartup(log) {
 }
 
 function checkLoadedGame(log) {
-    const startLoadedIndex = log.findIndex(l => l.startsWith("Loading game from file"));
+    let startLoadedIndex = log.findIndex(l => l.startsWith("Loading game from file"));
+    if (startLoadedIndex === -1) {
+        startLoadedIndex = 0; // Use all content if marker not found
+    }
     const loadedLog = log.slice(startLoadedIndex);
 
     const mods = getLoadedMods(loadedLog);
@@ -101,7 +104,10 @@ function getLoadedMods(loadedLog) {
 
 function getStartupLogs(loadedLog) {
     const firstLineIndex = loadedLog.findIndex(l => l.startsWith("Log file contents:"));
-    const lastLineIndex = loadedLog.findIndex(l => l.startsWith("Loading game from file"));
+    let lastLineIndex = loadedLog.findIndex(l => l.startsWith("Loading game from file"));
+    if (lastLineIndex === -1) {
+        lastLineIndex = loadedLog.length; // Use all content if marker not found
+    }
 
     const sliced = loadedLog.slice(firstLineIndex, lastLineIndex);
     const parsed = iterateLog(sliced, situations.startup);

--- a/assets/js/logParser/errors/could-not-load-reference.js
+++ b/assets/js/logParser/errors/could-not-load-reference.js
@@ -1,0 +1,11 @@
+registerClassifierNormal((content, situation) => {
+    const check = "Could not load reference to %s named %s";
+    const result = tryMatch(content, check);
+    if(!result) return null;
+    return {
+        type: "error",
+        content: result,
+        explanation: "A definition reference can't be loaded. This usually means a required mod is missing or the referenced item was removed.",
+        offendingModIds: [result[2]]
+    }
+});

--- a/assets/js/logParser/errors/null-key-while-loading.js
+++ b/assets/js/logParser/errors/null-key-while-loading.js
@@ -1,0 +1,11 @@
+registerClassifierNormal((content, situation) => {
+    const check = "Null key while loading dictionary of %s and %s. label=%s";
+    const result = tryMatch(content, check);
+    if(!result) return null;
+    return {
+        type: "error",
+        content: result,
+        explanation: "A mod is trying to load a dictionary with null keys. This indicates a configuration error in the mod's XML definitions.",
+        offendingModIds: [result[2].split('.')[0]]
+    }
+});

--- a/assets/js/logParser/logParser.js
+++ b/assets/js/logParser/logParser.js
@@ -43,6 +43,34 @@ function classifyLog(log, situation) {
         unknown: true
         };
     }
+    
+    // Check for common error patterns without filename info
+    const errorPatterns = [
+        "Could not load reference",
+        "Could not find",
+        "Could not resolve",
+        "Null key while loading",
+        "Config error",
+        "XML error",
+        "Failed to find"
+    ];
+    
+    // Exclude Harmony patch listings
+    const excludePatterns = [": PRE:", ": post:", ": TRANS:", "Prefixes:", "Postfixes:", "Transpilers:"];
+    if (excludePatterns.some(pattern => current.includes(pattern))) {
+        return null;
+    }
+    
+    if (errorPatterns.some(pattern => current.includes(pattern))) {
+        const known = checkClassifiersNormal(current, situation);
+        if(known) return known;
+        else return {
+            type: "error",
+            content: current,
+            unknown: true
+        };
+    }
+    
     // Other
     return {
         type: "message",


### PR DESCRIPTION
Fixes #10 

## Problem

  The log checker wasn't detecting errors in recent RimWorld logs. Users were seeing "undefined" text instead of   actual errors.

  ## Root Causes
  1. `getErrors`/`getWarnings` expected arrays but got objects from `_.groupBy`
  2. Newer logs don't always have "Loading game from file" marker
  3. Many errors don't include the `(Filename: ... Line: ...)` pattern anymore
  4. Missing classifiers for common errors like "Could not load reference" and "Null key while loading"

  ## Changes
  - Convert grouped objects to arrays before filtering
  - Add fallbacks when log markers are missing
  - Detect errors by pattern matching (excluding Harmony patches to avoid false positives)
  - Add two new error classifiers for common unrecognized errors
  - Properly handle null values to prevent "undefined" text in UI

  ## Testing
  Tested with the log from issue (gist 896679e6f97981c1d9ac3e1bc5bb315e) - now correctly shows 26 errors/warnings   instead of undefined text.